### PR TITLE
projects: Add libxdp

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -387,6 +387,10 @@ const ProjectDescriptions = () => (
             <a href="https://github.com/libbpf/libbpf">
               <b>libbpf</b>
             </a>{" "}
+            |{" "}
+            <a href="https://github.com/xdp-project/xdp-tools">
+              <b>libxdp</b>
+            </a>{" "}
             Emerging:
           </p>
           <p>
@@ -401,6 +405,14 @@ const ProjectDescriptions = () => (
             many existing gaps with BCC as a library. It also supports important
             features not available in BCC such as global variables and BPF
             skeletons.
+          </p>
+          <p>
+            <a href="https://github.com/xdp-project/xdp-tools">libxdp</a> is an
+            XDP-specific library that sits on top of libbpf and implements a
+            couple of XDP features: it supports loading of multiple programs to
+            run in sequence on the same interface, and it contains helper
+            functions for configuring AF_XDP sockets as well as reading and
+            writing packets from these sockets.
           </p>
         </div>
       </div>


### PR DESCRIPTION
This adds a mention of the libxdp library for managing multiple XDP
programs. The AF_XDP functionality of libbpf is also also in the process of
being moved to libxdp.

While the xdp-tools github project does not have the 50 committers listed as a requirement for a "major" project, libxdp contains code that has been moved from libbpf. More importantly, the AF_XDP functionality is being moved from libbpf without this meaning any lesser commitment to supporting it, an listing libxdp as an "emerging" project risks sending a signal that this functionality has been demoted in support level.

For this reason I believe it is appropriate to list libxdp along with libbpf as a "major" project, as this PR does.