### PR TITLE
Featured blogs: Add Arthur Chiao's blog

### DIFF
--- a/src/common/homepage/BlogRoll.js
+++ b/src/common/homepage/BlogRoll.js
@@ -54,6 +54,14 @@ export default class BlogRoll extends React.Component {
           category.toLowerCase().includes("bpf")
         ),
     },
+    {
+      url: "https%3A%2F%2Farthurchiao.art%2Ffeed.xml",
+      author: "Arthur Chiao",
+      filterBy: (post) =>
+        post.categories.some((category) =>
+          category.toLowerCase().includes("bpf")
+        ),
+    },
   ];
 
   constructor(props) {


### PR DESCRIPTION
Arthur has been publishing interesting posts about BPF ([last in date](https://arthurchiao.art/blog/differentiate-bpf-redirects/)), and his blog has a “BPF” category. Let's add it to the featured blogs.

Note that some of the posts are in Chinese. I do not believe this is an issue, because it still leaves a majority of English write-ups in the list with all the other featured blogs. If anything, it adds some diversity.

Note: I have not been able to test locally (the list of blog posts does not load when I serve locally).

Cc @ArthurChiao