### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -1,0 +1,11 @@
+If you're adding a new blog post, to avoid formatting problems on mobile, please ensure it includes a preview like this: 
+
+```
+{{preview}}
+
+Here goes the text which will be shown in a preview
+
+{{/preview}}
+```
+
+Reviewers - please check the preview on desktop and mobile before merging. 


### PR DESCRIPTION
Blog posts look terrible on ebpf.io on mobile if they don't include a preview section. Ideally this would be fixed as part of the template, but the workaround is to remind people to include it. 

Signed-off-by: Liz Rice <liz@lizrice.com>