### PR TITLE
menu: rearrange community items

### DIFF
--- a/src/components/shared/layout/layout.jsx
+++ b/src/components/shared/layout/layout.jsx
@@ -173,17 +173,12 @@ const headerMenu = [
         target: '_blank',
       },
       {
-        text: 'Contribute',
-        to: '/contribute',
-      },
-      {
         text: 'Newsletter',
         to: '/newsletter',
       },
       {
-        text: 'Branding',
-        to: 'https://ebpf.foundation/brand-guidelines/',
-        target: '_blank',
+        text: 'Contribute',
+        to: '/contribute',
       },
     ],
   },


### PR DESCRIPTION
And also remove branding item from there since it is enough to have it in the footer already.