### PR TITLE
feat: add redirect for /foundation/ page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -8,10 +8,12 @@
 /swag/ /swag.html
 /host-a-watch-party/ /host-a-watch-party.html
 /summit-2021-ctf/ /summit-2021-ctf.html
-/summit-2022/day-1/ https://youtu.be/0YqF45Kaapo 
+/summit-2022/day-1/ https://youtu.be/0YqF45Kaapo
 /summit-2022/day-2/ https://youtu.be/a3AwA1VdohU
 
 /slack/ https://cilium.herokuapp.com
+
+/foundation/ https://ebpf.foundation
 
 # It should be at the end of the file in order to keep redirects on top of it working
 /* https://ebpf-summit-2021.netlify.app/:splat 200


### PR DESCRIPTION
This PR adds redirect for /foundation/ page
[Preview](https://deploy-preview-391--ebpfio.netlify.app/foundation) (https://deploy-preview-391--ebpfio.netlify.app/foundation should redirect to https://ebpf.foundation/)