### PR TITLE
fix: updating gatsby-config to remove pwa functionality

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -102,8 +102,6 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
-        // name: 'ebpf-site',
-        // short_name: 'ebpf',
         start_url: '/',
         display: 'minimal-ui',
         icon: 'src/images/favicon.png',


### PR DESCRIPTION
This pull request removes `name` and `short_name` in [`gatsby-plugin-manifest`](https://www.gatsbyjs.com/plugins/gatsby-plugin-manifest/) to disable button "install app" in browsers

> The web app manifest (part of the [PWA](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) specification) enabled by this plugin allows users to add your site to their home screen on most mobile browsers — [see here](https://caniuse.com/web-app-manifest). The manifest provides configuration and icons to the phone.

**References**
https://w3c.github.io/manifest/#name-member

> The [manifest's](https://w3c.github.io/manifest/#dfn-manifest) name member is a [string](https://infra.spec.whatwg.org/#string) that represents the name of the web application as it is usually displayed to the user (e.g., amongst a list of other applications, or as a label for an icon).
> The name member serves as the [accessible name](https://www.w3.org/TR/accname-1.2/#dfn-accessible-name) of an [installed web application](https://w3c.github.io/manifest/#dfn-installed-web-application).