### PR TITLE
[Infrastructure landscape] Remove RedBPF from list of libraries

### DIFF
--- a/src/components/pages/project-landscape/ebpf-libraries/ebpf-libraries.jsx
+++ b/src/components/pages/project-landscape/ebpf-libraries/ebpf-libraries.jsx
@@ -36,7 +36,6 @@ const items = [
     icon: RustIcon,
     list: [
       `<a href="https://github.com/libbpf/libbpf-rs" target="_blank" rel="noopener noreferrer">libbpf-rs</a> is a safe, idiomatic, and opinionated wrapper API around libbpf written in Rust. libbpf-rs, together with libbpf-cargo (libbpf cargo plugin) allows to write 'compile once run everywhere' (CO-RE) eBPF programs.`,
-      '<a href="https://github.com/redsift/redbpf" target="_blank" rel="noopener noreferrer">redbpf</a> is a Rust eBPF toolchain that contains a collection of Rust libraries to work with eBPF programs.',
       '<a href="https://github.com/aya-rs/aya" target="_blank" rel="noopener noreferrer">aya</a> is an eBPF library built with a focus on operability and developer experience. It allows for both eBPF programs and their userspace programs to be written in Rust.',
     ],
   },


### PR DESCRIPTION
[The GitHub repository for RedBPF](https://github.com/foniod/redbpf) now displays the following banner:

    This repository has been archived by the owner on Jul 11, 2023.
    It is now read-only.

Therefore, the project no longer qualifies with the requirements for being listed:

    The project must be actively maintained.

This commit removes it from the landscape.