### PR TITLE
[Infrastructure landscape] Move bpftool to major infrastructure

### DIFF
--- a/src/data/pages/infrastructure/emerging.js
+++ b/src/data/pages/infrastructure/emerging.js
@@ -65,20 +65,6 @@ const emergingInfrastructure = [
     urls: [{ label: 'GitHub', url: 'https://github.com/vbpf/ebpf-verifier' }],
   },
   {
-    logoUrl: 'https://github.com/libbpf/bpftool',
-    name: 'bpftool',
-    logoName: 'bpftoolLogo',
-    title: 'Command-line tool to inspect and manage eBPF objects',
-    description: `Powered by libbpf, bpftool is the reference utility to
-    quickly inspect and manage BPF objects on a Linux system. Use it to list,
-    dump, or load eBPF programs and maps, to generate skeletons for eBPF
-    applications, to statically link eBPF programs from different object files,
-    or to perform various other eBPF-related tasks.`,
-    urls: [
-      { label: 'GitHub', url: 'https://github.com/libbpf/bpftool' },
-    ],
-  },
-  {
     name: 'BPF Conformance',
     title: 'eBPF Conformance Testing Framework',
     description: `A conformance testing framework for eBPF runtime implementations. It

--- a/src/data/pages/infrastructure/major.js
+++ b/src/data/pages/infrastructure/major.js
@@ -64,6 +64,18 @@ const majorInfrastructure = [
       { label: 'Docs', url: 'https://gcc.gnu.org/onlinedocs/gcc/eBPF-Options.html' },
     ],
   },
+  {
+    logoUrl: 'https://github.com/libbpf/bpftool',
+    name: 'bpftool',
+    logoName: 'bpftoolLogo',
+    title: 'Command-line tool to inspect and manage eBPF objects',
+    description: `Powered by libbpf, bpftool is the reference utility to
+    quickly inspect and manage BPF objects on a Linux system. Use it to list,
+    dump, or load eBPF programs and maps, to generate skeletons for eBPF
+    applications, to statically link eBPF programs from different object files,
+    or to perform various other eBPF-related tasks.`,
+    urls: [{ label: 'GitHub', url: 'https://github.com/libbpf/bpftool' }],
+  },
 ];
 
 export default majorInfrastructure;


### PR DESCRIPTION
I didn't check the requirements for infrastructure projects before adding bpftool to the emerging ones, but as Daniel observed, we can move it to the list of major projects. Both requirements are met:

- Looking at the history in the Linux kernel repository, bpftool has well over 50 contributors:

      $ git log --format='%an' -- tools/bpf/bpftool/ | sort -u | wc -l
      122

- The utility has been used in production by large companies as well as many system administrators, including:

  - For inspecting and managing eBPF objects
  - For probing eBPF features on the system, as Cilium did for a long time
  - For generating applications skeletons, including for building bpftool itself or parts of the Linux kernel (selftests, samples, pre-loaded eBPF iterators).