### PR TITLE
Use alternative logo on dark background on GitHub's README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 
-[![Logo](src/images/logo-black.svg)](https://ebpf.io)
+<a href="https://ebpf.io">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="src/images/logo-white.svg">
+    <img src="src/images/logo-black.svg" alt="Logo">
+  </picture>
+</a>
 
 This is the source code for the website [ebpf.io](https://ebpf.io/). For more information, see the [contribute](https://ebpf.io/contribute) page.
 


### PR DESCRIPTION
The change is for the GitHub repo only, not the generated website.

No change when a light background is in use:

![image](https://github.com/ebpf-io/ebpf.io-website/assets/17001771/546208a0-eb60-434a-ae08-335c99c87707)

But we use the white version of the logo when users selected a dark background for GitHub:

![image](https://github.com/ebpf-io/ebpf.io-website/assets/17001771/43af858f-f79d-4e0b-b0a7-5cb94b160d0e)
