### PR TITLE
chore: update links to Slack workspace

### DIFF
--- a/src/components/pages/newsletter/cards/cards.jsx
+++ b/src/components/pages/newsletter/cards/cards.jsx
@@ -38,7 +38,7 @@ const items = [
     links: [
       {
         text: 'Send on Slack',
-        to: 'https://cilium.herokuapp.com/',
+        to: 'https://slack.cilium.io/',
         target: '_blank',
       },
       {
@@ -63,13 +63,13 @@ const Cards = () => (
             {title}
           </h3>
           <p
-            className="mt-2.5 mb-[26px] max-w-[288px] sm:max-w-none [&_a]:font-semibold [&_a]:transition-colors [&_a]:duration-200 [&_a]:hover:text-gray-40"
+            className="mb-[26px] mt-2.5 max-w-[288px] sm:max-w-none [&_a]:font-semibold [&_a]:transition-colors [&_a]:duration-200 [&_a]:hover:text-gray-40"
             dangerouslySetInnerHTML={{ __html: description }}
           />
           <ul className="mt-auto flex space-x-4">
             {links.map(({ text, to, target }, index) => (
               <li
-                className="relative text-sm font-semibold uppercase leading-none tracking-wider before:absolute before:top-1/2 before:-left-2.5 before:block before:h-1 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-gray-90 first:before:hidden lg:text-[13px] md:text-xs"
+                className="relative text-sm font-semibold uppercase leading-none tracking-wider before:absolute before:-left-2.5 before:top-1/2 before:block before:h-1 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-gray-90 first:before:hidden lg:text-[13px] md:text-xs"
                 key={index}
               >
                 <Link

--- a/static/_redirects
+++ b/static/_redirects
@@ -10,7 +10,7 @@
 /summit-2022/day-1/ https://youtu.be/0YqF45Kaapo
 /summit-2022/day-2/ https://youtu.be/a3AwA1VdohU
 
-/slack/ https://cilium.herokuapp.com
+/slack/ https://slack.cilium.io/
 
 /foundation/ https://ebpf.foundation
 

--- a/static/summit-2020.html
+++ b/static/summit-2020.html
@@ -5435,7 +5435,7 @@
               </p>
               <div class="space"></div>
               <div class="buttons">
-                <a class="button type--join" href="https://cilium.herokuapp.com/"
+                <a class="button type--join" href="https://slack.cilium.io/"
                   >Join eBPF Summit Slack</a
                 >
               </div>


### PR DESCRIPTION
The Heroku instance was removed a few days ago. We need to update the links to have them point to https://slack.cilium.io/ instead.

Fixes: https://github.com/ebpf-io/ebpf.io-website/issues/621
