### PR TITLE
Update link to eBPF docs

### DIFF
--- a/src/data/shared/header-menu.js
+++ b/src/data/shared/header-menu.js
@@ -81,7 +81,7 @@ const headerMenu = [
       },
       {
         title: 'eBPF Docs',
-        to: 'https://ebpf-docs.dylanreimerink.nl/',
+        to: 'https://docs.ebpf.io/',
         target: '_blank',
       },
       {


### PR DESCRIPTION
The eBPF docs have moved to a new location. This commit updates the link in the header menu to point to the new location.