### PR TITLE
fix: turn-off automatic redirection to the user's language

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -178,6 +178,7 @@ module.exports = {
         defaultLanguage,
         siteUrl: process.env.GATSBY_DEFAULT_SITE_URL,
         trailingSlash: 'always',
+        redirect: false,
         i18nextOptions: {
           load: 'all',
           lowerCaseLng: true,


### PR DESCRIPTION
**Describe what changes this pull request brings**

Disable automatic redirection based on the user’s preferred language. Users can still manually change the website’s locale and access the appropriate translation

**Steps to check**:

1. Open [preview](https://deploy-preview-655--ebpfio.netlify.app/)
2. Make sure that everything looks and works as expected