### PR TITLE
Fix FOSDEM devroom mailing list URL on FOSDEM CfP

### DIFF
--- a/static/fosdem-2025.html
+++ b/static/fosdem-2025.html
@@ -262,9 +262,9 @@ href="https://pretalx.fosdem.org/fosdem-2025/cfp">Pretalx</a>, FOSDEM’s
 submissions tool.</p>
 <p>Make sure to <strong>select “eBPF” as the track</strong>.</p>
 <p>The official communication channel for the Devroom is the dedicated
-FOSDEM mailing list, <a href="mailto:ebpf-devroom@lists.fosdem.org"
-class="email">ebpf-devroom@lists.fosdem.org</a>. Please make sure to
-join if you submit a talk.</p>
+FOSDEM mailing list, <a
+href="https://lists.fosdem.org/listinfo/ebpf-devroom">ebpf-devroom@lists.fosdem.org</a>.
+Please make sure to join if you submit a talk.</p>
 <h2 id="code-of-conduct">Code of Conduct</h2>
 <p>All participants at FOSDEM are expected to abide by the <a
 href="https://fosdem.org/2025/practical/conduct/">FOSDEM’s Code of


### PR DESCRIPTION
The URL for the link is a mailto: to the actual mailing list address. This is not useful for subscribing to the list; use the list information page instead.
