### PR TITLE
Add a script to automate stars update

### DIFF
--- a/scripts/update-stars.sh
+++ b/scripts/update-stars.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+
+DATA_FILES=(
+    "src/data/pages/applications/emerging.json"
+    "src/data/pages/applications/major.json"
+)
+
+get_projects_from_file() {
+    local file="$1"
+
+    jq '[ .[] | { name: .name, github: (.urls[] | select(.label=="GitHub").url), stars: .githubStars } ]' \
+        "${file}"
+}
+
+get_project() {
+    local projects="$1" index="$2"
+
+    echo "${projects}" | jq ".[$index]"
+}
+
+projects_nb() {
+    local project="$1"
+    echo "${project}" | jq 'length'
+}
+
+project_name() {
+    local project="$1"
+    echo "${project}" | jq -r '.name'
+}
+
+project_gh_repo() {
+    local project="$1"
+    echo "${project}" | jq -r '.github'
+}
+
+project_stars() {
+    local project="$1"
+    echo "${project}" | jq -r '.stars'
+}
+
+get_stars_count() {
+    local gh_repo="$1" repo_path
+
+    # Use the 'gh' CLI
+    #repo_path="repos/${gh_repo#https://github.com/}"
+    #gh api "${repo_path}" --jq '.stargazers_count'
+
+    # Use the 'curl' command
+    url="https://api.github.com/repos/${gh_repo#https://github.com/}"
+    headers=(
+        '-H "Accept: application/vnd.github+json"'
+        "-H 'Authorization: Bearer ${GITHUB_TOKEN}'"
+        '-H "X-GitHub-Api-Version: 2022-11-28"'
+    )
+    curl -L "${headers[@]}" "${url}" | jq '.stargazers_count'
+}
+
+print_progress() {
+    local current="$1" total="$2"
+    printf '  [%02u/%02u] ' "${current}" "${total}"
+}
+
+update_file() {
+    local file="$1" name="$2" stars="$3"
+
+    jq --arg name "${name}" --arg stars "${stars}" \
+        '(.[] | select(.name == $name) | .githubStars) = ($stars | tonumber)' \
+        "${file}" > "${file}.tmp"
+    mv "${file}.tmp" "${file}"
+}
+
+process_project() {
+    local project="$1" file="$2"
+    local name stars gh_repo
+    local stars_update
+
+    name=$(project_name "${project}")
+    stars=$(project_stars "${project}")
+    gh_repo=$(project_gh_repo "${project}")
+
+    echo "  Processing project: ${name}"
+    echo "    repository: ${gh_repo}, stars: ${stars}"
+
+    stars_update=$(get_stars_count "${gh_repo}")
+    echo "    new stars count: ${stars_update}"
+
+    update_file "${file}" "${name}" "${stars_update}"
+}
+
+process_file() {
+    local file="$1" projects_nb
+    echo "Processing ${file}"
+
+    projects="$(get_projects_from_file "${file}")"
+    projects_nb="$(projects_nb "${projects}")"
+
+    for ((i = 0; i < projects_nb; i++)); do
+        project="$(get_project "${projects}" "${i}")"
+        print_progress "$((i + 1))" "${projects_nb}"
+        process_project "${project}" "${file}"
+    done
+}
+
+process_all_files() {
+    for file in "${DATA_FILES[@]}"; do
+        process_file "$file"
+    done
+}
+
+process_all_files

--- a/src/data/pages/applications/emerging.json
+++ b/src/data/pages/applications/emerging.json
@@ -465,7 +465,7 @@
     "description": "KubeSkoop is a toolset designed to assist users in monitoring and diagnosing network-related issues within Kubernetes environments. It uses eBPF to provide pod-level kernel metrics and anomaly events, enabling users quickly detect and solve network issues in their Kubernetes clusters.",
     "urls": [
       {
-        "label": "Github",
+        "label": "GitHub",
         "url": "https://github.com/alibaba/kubeskoop"
       },
       {
@@ -484,7 +484,7 @@
     "urls": [
       {
         "label": "GitHub",
-        "url": "https://github.com/l3af-project"
+        "url": "https://github.com/l3af-project/l3afd"
       },
       {
         "label": "Website",
@@ -675,7 +675,7 @@
     "description": "bpfilter transforms how you control network traffic by leveraging the power of eBPF technology. This framework elegantly translates filtering rules into optimized BPF programs, bringing unparalleled performance and flexibility to your packet filtering needs.",
     "urls": [
       {
-        "label": "Github",
+        "label": "GitHub",
         "url": "https://github.com/facebook/bpfilter"
       },
       {

--- a/src/data/pages/applications/emerging.json
+++ b/src/data/pages/applications/emerging.json
@@ -15,7 +15,7 @@
         "url": "https://pyroscope.io/"
       }
     ],
-    "githubStars": 10400
+    "githubStars": 10626
   },
   {
     "logoUrl": "https://github.com/gojue/ecapture",
@@ -33,7 +33,7 @@
         "url": "https://ecapture.cc/"
       }
     ],
-    "githubStars": 14000
+    "githubStars": 14380
   },
   {
     "logoUrl": "https://github.com/coroot/coroot",
@@ -51,7 +51,7 @@
         "url": "https://coroot.com/"
       }
     ],
-    "githubStars": 5700
+    "githubStars": 6532
   },
   {
     "logoUrl": "https://github.com/cilium/hubble",
@@ -69,7 +69,7 @@
         "url": "https://cilium.io/"
       }
     ],
-    "githubStars": 3700
+    "githubStars": 3812
   },
   {
     "logoUrl": "https://github.com/aquasecurity/tracee",
@@ -83,7 +83,7 @@
         "url": "https://github.com/aquasecurity/tracee"
       }
     ],
-    "githubStars": 3800
+    "githubStars": 3919
   },
   {
     "logoUrl": "https://github.com/keyval-dev/odigos",
@@ -101,7 +101,7 @@
         "url": "https://odigos.io"
       }
     ],
-    "githubStars": 3400
+    "githubStars": 3443
   },
   {
     "logoUrl": "https://github.com/cilium/pwru",
@@ -115,7 +115,7 @@
         "url": "https://github.com/cilium/pwru"
       }
     ],
-    "githubStars": 3200
+    "githubStars": 3352
   },
   {
     "logoUrl": "https://github.com/deepflowys/deepflow",
@@ -133,7 +133,7 @@
         "url": "https://deepflow.yunshan.net/community.html"
       }
     ],
-    "githubStars": 3200
+    "githubStars": 3339
   },
   {
     "logoUrl": "https://github.com/iovisor/kubectl-trace",
@@ -147,7 +147,7 @@
         "url": "https://github.com/iovisor/kubectl-trace"
       }
     ],
-    "githubStars": 2100
+    "githubStars": 2111
   },
   {
     "logoUrl": "https://github.com/daeuniverse/dae",
@@ -161,7 +161,7 @@
         "url": "https://github.com/daeuniverse/dae"
       }
     ],
-    "githubStars": 3800
+    "githubStars": 4287
   },
   {
     "logoUrl": "https://github.com/microsoft/retina",
@@ -179,7 +179,7 @@
         "url": "https://retina.sh"
       }
     ],
-    "githubStars": 2900
+    "githubStars": 2976
   },
   {
     "logoUrl": "https://github.com/hengyoush/kyanos",
@@ -197,7 +197,7 @@
         "url": "https://kyanos.io"
       }
     ],
-    "githubStars": 4000
+    "githubStars": 4428
   },
   {
     "logoUrl": "https://github.com/kinvolk/inspektor-gadget",
@@ -215,7 +215,7 @@
         "url": "https://www.inspektor-gadget.io/"
       }
     ],
-    "githubStars": 2400
+    "githubStars": 2477
   },
   {
     "logoUrl": "https://github.com/Sysinternals/SysmonForLinux",
@@ -229,7 +229,7 @@
         "url": "https://github.com/Sysinternals/SysmonForLinux"
       }
     ],
-    "githubStars": 1800
+    "githubStars": 1896
   },
   {
     "logoUrl": "https://github.com/groundcover-com/caretta",
@@ -243,7 +243,7 @@
         "url": "https://github.com/groundcover-com/caretta"
       }
     ],
-    "githubStars": 1900
+    "githubStars": 1922
   },
   {
     "logoUrl": "https://github.com/solo-io/bumblebee",
@@ -261,7 +261,7 @@
         "url": "https://bumblebee.io/"
       }
     ],
-    "githubStars": 1300
+    "githubStars": 1287
   },
   {
     "logoUrl": "https://github.com/kubearmor/KubeArmor",
@@ -279,7 +279,7 @@
         "url": "https://kubearmor.com"
       }
     ],
-    "githubStars": 1700
+    "githubStars": 1740
   },
   {
     "logoUrl": "https://github.com/grafana/beyla",
@@ -297,7 +297,7 @@
         "url": "https://grafana.com/oss/beyla-ebpf/"
       }
     ],
-    "githubStars": 1600
+    "githubStars": 1708
   },
   {
     "logoUrl": "https://github.com/iovisor/ply",
@@ -315,7 +315,7 @@
         "url": "https://wkz.github.io/ply/"
       }
     ],
-    "githubStars": 996
+    "githubStars": 1004
   },
   {
     "logoUrl": "https://github.com/sustainable-computing-io/kepler",
@@ -333,7 +333,7 @@
         "url": "https://sustainable-computing.io"
       }
     ],
-    "githubStars": 1300
+    "githubStars": 1326
   },
   {
     "logoUrl": "https://github.com/Exein-io/pulsar",
@@ -351,7 +351,7 @@
         "url": "https://pulsar.sh/"
       }
     ],
-    "githubStars": 993
+    "githubStars": 954
   },
   {
     "logoUrl": "https://github.com/merbridge/merbridge",
@@ -369,7 +369,7 @@
         "url": "https://merbridge.io/"
       }
     ],
-    "githubStars": 771
+    "githubStars": 782
   },
   {
     "logoUrl": "https://github.com/kindlingproject/kindling",
@@ -387,7 +387,7 @@
         "url": "http://kindling.harmonycloud.cn"
       }
     ],
-    "githubStars": 1000
+    "githubStars": 1044
   },
   {
     "logoUrl": "https://github.com/rubrikinc/wachy",
@@ -405,7 +405,7 @@
         "url": "https://rubrikinc.github.io/wachy/"
       }
     ],
-    "githubStars": 564
+    "githubStars": 573
   },
   {
     "logoUrl": "https://github.com/qpoint-io/qtap",
@@ -423,7 +423,7 @@
         "url": "https://qpoint.io/qtap/"
       }
     ],
-    "githubStars": 675
+    "githubStars": 1137
   },
   {
     "logoUrl": "https://github.com/getanteon/alaz",
@@ -473,7 +473,7 @@
         "url": "https://kubeskoop.io"
       }
     ],
-    "githubStars": 678
+    "githubStars": 643
   },
   {
     "logoUrl": "https://github.com/l3af-project",
@@ -491,7 +491,7 @@
         "url": "https://l3af.io"
       }
     ],
-    "githubStars": 726
+    "githubStars": 197
   },
   {
     "logoUrl": "https://skywalking.apache.org/",
@@ -509,7 +509,7 @@
         "url": "https://skywalking.apache.org/"
       }
     ],
-    "githubStars": 216
+    "githubStars": 221
   },
   {
     "logoUrl": "https://github.com/loxilb-io/loxilb",
@@ -527,7 +527,7 @@
         "url": "https://www.loxilb.io/"
       }
     ],
-    "githubStars": 1600
+    "githubStars": 1676
   },
   {
     "logoUrl": "https://github.com/bpfman/bpfman",
@@ -545,7 +545,7 @@
         "url": "https://bpfman.io"
       }
     ],
-    "githubStars": 593
+    "githubStars": 635
   },
   {
     "logoUrl": "https://github.com/kong/blixt",
@@ -559,7 +559,7 @@
         "url": "https://github.com/kong/blixt"
       }
     ],
-    "githubStars": 397
+    "githubStars": 424
   },
   {
     "logoUrl": "https://github.com/netobserv/netobserv-ebpf-agent",
@@ -573,7 +573,7 @@
         "url": "https://github.com/netobserv/netobserv-ebpf-agent"
       }
     ],
-    "githubStars": 157
+    "githubStars": 174
   },
   {
     "logoUrl": "https://github.com/openshift/ingress-node-firewall",
@@ -587,7 +587,7 @@
         "url": "https://github.com/openshift/ingress-node-firewall"
       }
     ],
-    "githubStars": 52
+    "githubStars": 56
   },
   {
     "logoUrl": "https://github.com/Netflix/bpftop",
@@ -601,7 +601,7 @@
         "url": "https://github.com/Netflix/bpftop"
       }
     ],
-    "githubStars": 2400
+    "githubStars": 2467
   },
   {
     "logoUrl": "https://github.com/tarsal-oss/kflowd",
@@ -619,7 +619,7 @@
         "url": "https://tarsal.co/kflow/"
       }
     ],
-    "githubStars": 58
+    "githubStars": 64
   },
   {
     "logoUrl": "https://github.com/open-telemetry/opentelemetry-ebpf-profiler",
@@ -633,7 +633,7 @@
         "url": "https://github.com/open-telemetry/opentelemetry-ebpf-profiler"
       }
     ],
-    "githubStars": 2700
+    "githubStars": 2770
   },
   {
     "logoUrl": "https://github.com/davidcoles/vc5",
@@ -647,7 +647,7 @@
         "url": "https://github.com/davidcoles/vc5"
       }
     ],
-    "githubStars": 83
+    "githubStars": 93
   },
   {
     "logoUrl": "https://github.com/kubescape/kubescape",
@@ -665,7 +665,7 @@
         "url": "https://kubescape.io/"
       }
     ],
-    "githubStars": 10700
+    "githubStars": 10810
   },
   {
     "logoUrl": "https://github.com/facebook/bpfilter",
@@ -683,6 +683,6 @@
         "url": "https://bpfilter.io/"
       }
     ],
-    "githubStars": 224
+    "githubStars": 233
   }
 ]

--- a/src/data/pages/applications/major.json
+++ b/src/data/pages/applications/major.json
@@ -40,7 +40,7 @@
     "urls": [
       {
         "label": "GitHub",
-        "url": "https://github.com/iovisor/bpftrace"
+        "url": "https://github.com/bpftrace/bpftrace"
       },
       {
         "label": "Website",

--- a/src/data/pages/applications/major.json
+++ b/src/data/pages/applications/major.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/iovisor/bcc"
       }
     ],
-    "githubStars": 21100
+    "githubStars": 21466
   },
   {
     "logoUrl": "https://github.com/cilium/cilium",
@@ -29,7 +29,7 @@
         "url": "https://cilium.io"
       }
     ],
-    "githubStars": 21200
+    "githubStars": 21796
   },
   {
     "logoUrl": "https://github.com/iovisor/bpftrace",
@@ -47,7 +47,7 @@
         "url": "https://bpftrace.org/"
       }
     ],
-    "githubStars": 1400
+    "githubStars": 9269
   },
   {
     "logoUrl": "https://github.com/falcosecurity/falco",
@@ -65,7 +65,7 @@
         "url": "https://falco.org/"
       }
     ],
-    "githubStars": 7700
+    "githubStars": 7984
   },
   {
     "logoUrl": "https://github.com/pixie-io/pixie",
@@ -83,7 +83,7 @@
         "url": "https://px.dev"
       }
     ],
-    "githubStars": 5900
+    "githubStars": 6048
   },
   {
     "logoUrl": "https://github.com/projectcalico/calico",
@@ -101,7 +101,7 @@
         "url": "https://tigera.io/project-calico"
       }
     ],
-    "githubStars": 6300
+    "githubStars": 6508
   },
   {
     "logoUrl": "https://github.com/facebookincubator/katran",
@@ -119,7 +119,7 @@
         "url": "https://engineering.fb.com/open-source/open-sourcing-katran-a-scalable-network-load-balancer/"
       }
     ],
-    "githubStars": 4900
+    "githubStars": 4964
   },
   {
     "logoUrl": "https://github.com/parca-dev/parca",
@@ -137,7 +137,7 @@
         "url": "https://parca.dev"
       }
     ],
-    "githubStars": 4300
+    "githubStars": 4466
   },
   {
     "logoUrl": "https://github.com/cilium/tetragon",
@@ -155,6 +155,6 @@
         "url": "https://tetragon.io/"
       }
     ],
-    "githubStars": 3900
+    "githubStars": 4013
   }
 ]


### PR DESCRIPTION
Add a script to automatically retrieve the number of GitHub stars for the different project listed on the landscape page (applications, not infrastructure), so that they can be sorted more accurately. The script requires `jq` and `curl` (and a valid GitHub token).

In the future, this script could be run on a regular basis in CI to automatically generate pull requests to update the number of stars, on a monthly basis for example.

Run the script to update the number of stars for the project. Most projects earned a few stars, a few lost some stars.