### PR TITLE
fix: update RAD Security blog post links

### DIFF
--- a/content/blog-posts/2024-01-30-rad-security/index.md
+++ b/content/blog-posts/2024-01-30-rad-security/index.md
@@ -2,8 +2,8 @@
 date: '2024-01-30T12:33:00.000Z'
 title: 'Verified runtime fingerprints to eliminate zero day software supply chain attacks'
 ogImage: ogimage.webp
-description: 'KSOC announce the availability of the eBPF-based RAD security standard, to help the cloud native security ecosystem combat the wave of software supply chain attacks'
-externalUrl: 'https://ksoc.com/blog/introducing-rad-security'
+description: 'RAD Security announces the availability of the eBPF-based RAD security standard, to help the cloud native security ecosystem combat the wave of software supply chain attacks'
+externalUrl: 'https://www.radsecurity.ai/blog/introducing-rad-security'
 categories:
   - Technology
 ---

--- a/locales/en/case-studies.json
+++ b/locales/en/case-studies.json
@@ -134,7 +134,7 @@
       "description": "<strong>Meta</strong> uses eBPF to process and load balance every packet coming into their data centers",
       "links": [
         {
-          "text": "Case Study", 
+          "text": "Case Study",
           "to": "https://ebpf.foundation/case-study-metas-strobelight-leverages-ebpf-to-reduce-cpu-cycles-and-server-demands-by-up-to-20/"
         },
         {
@@ -617,7 +617,7 @@
       "links": [
         {
           "text": "Blog",
-          "to": "https://ksoc.com/blog/introducing-rad-security"
+          "to": "https://www.radsecurity.ai/blog/introducing-rad-security"
         }
       ]
     },

--- a/locales/es/case-studies.json
+++ b/locales/es/case-studies.json
@@ -599,7 +599,7 @@
       "links": [
         {
           "text": "Blog",
-          "to": "https://ksoc.com/blog/introducing-rad-security"
+          "to": "https://www.radsecurity.ai/blog/introducing-rad-security"
         }
       ]
     },

--- a/locales/hi-in/case-studies.json
+++ b/locales/hi-in/case-studies.json
@@ -609,7 +609,7 @@
       "links": [
         {
           "text": "ब्लॉग",
-          "to": "https://ksoc.com/blog/introducing-rad-security"
+          "to": "https://www.radsecurity.ai/blog/introducing-rad-security"
         }
       ]
     },

--- a/locales/ja/case-studies.json
+++ b/locales/ja/case-studies.json
@@ -599,7 +599,7 @@
       "links": [
         {
           "text": "Blog",
-          "to": "https://ksoc.com/blog/introducing-rad-security"
+          "to": "https://www.radsecurity.ai/blog/introducing-rad-security"
         }
       ]
     },

--- a/locales/ko-kr/case-studies.json
+++ b/locales/ko-kr/case-studies.json
@@ -599,7 +599,7 @@
       "links": [
         {
           "text": "Blog",
-          "to": "https://ksoc.com/blog/introducing-rad-security"
+          "to": "https://www.radsecurity.ai/blog/introducing-rad-security"
         }
       ]
     },


### PR DESCRIPTION
Resolves https://github.com/ebpf-io/ebpf.io-website/issues/729

Updates branding to RAD Security from the previous KSOC Labs, and fixes related URLs.