### PR TITLE
adding freertr

### DIFF
--- a/src/data/pages/applications/emerging.json
+++ b/src/data/pages/applications/emerging.json
@@ -756,5 +756,23 @@
       }
     ],
     "githubStars": 1084
+  },
+  {
+    "logoUrl": "https://github.com/mc36/freeRtr",
+    "name": "freerouter",
+    "logoName": "freertrLogo",
+    "title": " freeRouter - networking swiss army knife",
+    "description": "freerouter is an open source project router focusing on routing protocols with one of the fastpaths implemented in bpf"
+    "urls": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/mc36/freeRtr"
+      },
+      {
+        "label": "Website",
+        "url": "http://freertr.org/"
+      }
+    ],
+    "githubStars": 97
   }
 ]


### PR DESCRIPTION
if you have any comments, please let me know...

imho the only questionable point is "The project must be using eBPF as its underlying core technology" which holds as the available dataplanes are asic, openflow, dpdk, pcap/raw/xdp packetio and ebpf... the first 2 are dead for years now, dpdk is not available on most of the (low end) hardware and raw sockets based forwarding have an overhead...

its a monorepo so the ebpf forwarder is https://github.com/mc36/freeRtr/blob/master/misc/native/p4xdp_kern.c , the pre-loop version is https://github.com/mc36/freeRtr/blob/master/misc/native/p4xdp_krno.c and https://github.com/mc36/freeRtr/tree/master/misc/openwrt-p4xdp is the owrt boilerplate
