### PR TITLE
Promote OTel eBPF Profiler to major application

### DIFF
--- a/src/data/pages/applications/emerging.json
+++ b/src/data/pages/applications/emerging.json
@@ -608,20 +608,6 @@
     "githubStars": 71
   },
   {
-    "logoUrl": "https://github.com/open-telemetry/opentelemetry-ebpf-profiler",
-    "name": "OpenTelemetry eBPF Profiler",
-    "logoName": "otelLogo",
-    "title": "Whole-system, cross-language continuous profiler for Linux",
-    "description": "The Open Telemetry eBPF-based continuous profiler offers comprehensive, low-overhead whole-system profiling for Linux systems. It supports a wide range of programming languages, including native code without debug symbols, and provides deep insights into application behavior. By leveraging the experimental OTel profiling signals, this project empowers developers to identify performance bottlenecks and optimize their applications efficiently.",
-    "urls": [
-      {
-        "label": "GitHub",
-        "url": "https://github.com/open-telemetry/opentelemetry-ebpf-profiler"
-      }
-    ],
-    "githubStars": 3019
-  },
-  {
     "logoUrl": "https://github.com/davidcoles/vc5",
     "name": "vc5",
     "logoName": "vc5Logo",

--- a/src/data/pages/applications/major.json
+++ b/src/data/pages/applications/major.json
@@ -156,5 +156,19 @@
       }
     ],
     "githubStars": 4417
+  },
+  {
+    "logoUrl": "https://github.com/open-telemetry/opentelemetry-ebpf-profiler",
+    "name": "OpenTelemetry eBPF Profiler",
+    "logoName": "otelLogo",
+    "title": "Whole-system, cross-language continuous profiler for Linux",
+    "description": "The Open Telemetry eBPF-based continuous profiler offers comprehensive, low-overhead whole-system profiling for Linux systems. It supports a wide range of programming languages, including native code without debug symbols, and provides deep insights into application behavior. By leveraging the experimental OTel profiling signals, this project empowers developers to identify performance bottlenecks and optimize their applications efficiently.",
+    "urls": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/open-telemetry/opentelemetry-ebpf-profiler"
+      }
+    ],
+    "githubStars": 3084
   }
 ]


### PR DESCRIPTION
OTel eBPF profiler is used in various environments, including Elastic, Datadog and Shopify. At KubeCon Amsterdam, we gave a short talk where eBPF profiler was used: https://www.youtube.com/watch?v=TKp2snmgvtQ

Other listed major eBPF applications use it also as [dependency](https://github.com/parca-dev/parca-agent/blob/fa5c3c35c819917aa869394ac3f3d3a163c6a5b6/go.mod#L38).